### PR TITLE
A few fixes and Tinker compat

### DIFF
--- a/include/EditorUI.hpp
+++ b/include/EditorUI.hpp
@@ -96,5 +96,6 @@ class $modify(MyEditorUI, EditorUI) {
 	void toggleSearch(bool forceToggleOff=false);
 	void performSearchResult(const std::string& query);
 
+	void updateGroupItem(int id);
 	void goToObject(int id, bool openIfInGroup, bool playEffect=true);
 };

--- a/include/ObjectFoundEvent.hpp
+++ b/include/ObjectFoundEvent.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <Geode/loader/Event.hpp>
+#include <Geode/binding/CreateMenuItem.hpp>
+
+namespace razoom {
+
+class ObjectFoundEvent : public geode::Event<ObjectFoundEvent, bool(CreateMenuItem*)> {
+    using Event::Event;
+};
+
+}

--- a/mod.json
+++ b/mod.json
@@ -1,5 +1,5 @@
 {
-	"geode": "5.0.0",
+	"geode": "5.6.0",
 	"gd": {
 		"win": "2.2081",
 		"android": "2.2081",
@@ -29,6 +29,12 @@
 			"version": ">=1.0.1",
 			"required": false
 		}
+	},
+
+	"api": {
+		"include": [
+			"include/ObjectFoundEvent.hpp"
+		]
 	},
 
 	"resources": {

--- a/src/EditorUI.cpp
+++ b/src/EditorUI.cpp
@@ -1,6 +1,7 @@
 #include "EditorUI.hpp"
 #include "MoreOptionsPopup.hpp"
 #include "SearchPopup.hpp"
+#include "ObjectFoundEvent.hpp"
 #include <alphalaneous.editortab_api/include/EditorTabAPI.hpp>
 
 // mathematically correct a % b
@@ -213,6 +214,7 @@ void MyEditorUI::setupExtraTabs(std::set<uint8_t> const &which) {
 		alpha::editor_tabs::addTab(tabId, alpha::editor_tabs::BUILD,
 			[this, rows, cols, i] { // Crate the tab
 				auto ret = alpha::editor_tabs::createEditButtonBar({});
+				ret->m_hasCreateItems = true;
 
 				ret->setUserObject(BAR_USER_OBJ_ID, new BarInfo(13+i));
 				loadGroups(ret, ret->m_buttonArray, 13+i, cols, rows, true);
@@ -998,6 +1000,41 @@ void MyEditorUI::onGotoObjectBtn(CCObject*) {
 	}
 }
 
+void MyEditorUI::updateGroupItem(int id) {
+
+	auto allTabs = alpha::editor_tabs::getAllTabs();
+	if (!allTabs) return;
+
+	// foreach tab
+	int barIndex = -1;
+	for (auto node : *allTabs) {
+		barIndex++;
+		if (!tryGetBarInfo(node)) continue;
+
+		auto bar = static_cast<EditButtonBar*>(node);
+		auto shortTabId = convertToEditorTabApiId(node->getID());
+		
+		// foreach item in my tab
+		int buttonIndex = -1;
+		for (auto* cmi : CCArrayExt<CreateMenuItem*>(bar->m_buttonArray)) {
+			buttonIndex++;
+			auto group = static_cast<Group*>(cmi->getUserObject(CMI_USER_OBJ_ID));
+			if (group) { // group
+				auto &matrix = group->getMatrix();
+				for (int i = 0; i < matrix.size(); i++) {
+					auto &row = matrix[i];
+					for (int j = 0; j < row.size(); j++) {
+						if (id == row[j]) {
+							setNewSelectedGroupCmi(cmi);
+							razoom::ObjectFoundEvent().send(cmi);
+							return;
+						}
+					}
+				}
+			}
+		}
+	}
+}
 
 void MyEditorUI::goToObject(int id, bool openIfInGroup, bool playEffect) {
 
@@ -1028,6 +1065,7 @@ void MyEditorUI::goToObject(int id, bool openIfInGroup, bool playEffect) {
 					int currentPage = buttonIndex / pgSize;
 					alpha::editor_tabs::switchTab(shortTabId);
 					bar->goToPage(currentPage);
+					razoom::ObjectFoundEvent().send(cmi);
 					
 					if (playEffect) {
 						playCircleEffectOnCmi(cmi);
@@ -1052,6 +1090,9 @@ void MyEditorUI::goToObject(int id, bool openIfInGroup, bool playEffect) {
 								cmi->activate(); // open group
 								openedOrPinned = true;
 							}
+
+							setNewSelectedGroupCmi(cmi);
+							razoom::ObjectFoundEvent().send(cmi);
 
 							if (playEffect) {
 								if (openedOrPinned) {

--- a/src/EditorUIHooks.cpp
+++ b/src/EditorUIHooks.cpp
@@ -255,6 +255,7 @@ void MyEditorUI::updateCreateMenu(bool p0) {
 		}
 		if (p0) { // goto object
 			goToObject(m_selectedObjectIndex, false, false);
+			updateGroupItem(m_selectedObjectIndex);
 		}
 	}
 }

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -510,6 +510,7 @@ public:
             CC_SAFE_DELETE(ret);
             return nullptr;
         }
+        ret->autorelease();
         return ret;
     }
 
@@ -524,6 +525,13 @@ public:
         effect->m_opacityMod = 0.75;
         addChild(effect);
         
+        effect->addOnExitCallback([this] {
+            // if both itself and the effect exit at the same time, it will cause cocos to recurse, delay by a frame
+            runAction(CallFuncExt::create([this] {
+                removeFromParent();
+            }));
+        });
+
         return true;
     }
 
@@ -531,47 +539,22 @@ public:
         setVisible(false);
         CCNode::cleanup();
     }
-
-    void removeChild(CCNode* child, bool cleanup) override {
-        CCNode::removeChild(child, cleanup);
-        removeFromParent();
-    }
 };
-
 
 void playCircleEffectOnCmi(CreateMenuItem* cmi) {
     if (!cmi) return;
-    auto worldPoint = cmi->convertToWorldSpace(cmi->getContentSize() / 2);
-    if (auto maybeMenu = cmi->getParent()) {
-        if (auto maybeButtonPage = maybeMenu->getParent()) {
-            if (auto extendedLayer = typeinfo_cast<ExtendedLayer*>(maybeButtonPage->getParent())) {
-                auto nodePoint = extendedLayer->convertToNodeSpace(worldPoint);
-                float scale = extendedLayer->getScale() * maybeButtonPage->getScale() * maybeMenu->getScale();
-                auto effect = AutoCleanedCircleWave::create(scale);
-                extendedLayer->removeChildByID("wave"_spr);
-                extendedLayer->addChild(effect);
-                effect->setPosition(nodePoint);
-                effect->setZOrder(100);
-                effect->setID("wave"_spr);
-                return;
-            }
-        }
-    }
-    if (auto maybeMenu = cmi->getParent()) {
-        if (auto maybeGroup = maybeMenu->getParent()) {
-            if (maybeGroup->getID() == "RaZooM") {
-                auto nodePoint = maybeGroup->convertToNodeSpace(worldPoint);
-                float scale = maybeGroup->getScale() * maybeMenu->getScale();
-                auto effect = AutoCleanedCircleWave::create(scale);
-                maybeGroup->removeChildByID("wave"_spr);
-                maybeGroup->addChild(effect);
-                effect->setPosition(nodePoint);
-                effect->setZOrder(100);
-                effect->setID("wave"_spr);
-                return;
-            }
-        }
-    }
+
+    cmi->removeChildByID("wave"_spr);
+
+    // wait a frame to skip unschedule when cmi is clicked
+    queueInMainThread([cmi = Ref(cmi)] {
+        auto effect = AutoCleanedCircleWave::create(1.f);
+        effect->setPosition(cmi->getContentSize() / 2);
+        effect->setZOrder(100);
+        effect->setID("wave"_spr);
+
+        cmi->addChild(effect);
+    });
 }
 
 

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -524,13 +524,6 @@ public:
         effect = CCCircleWave::create(0, 45 * scale, 1.6, false, true);
         effect->m_opacityMod = 0.75;
         addChild(effect);
-        
-        effect->addOnExitCallback([this] {
-            // if both itself and the effect exit at the same time, it will cause cocos to recurse, delay by a frame
-            runAction(CallFuncExt::create([this] {
-                removeFromParent();
-            }));
-        });
 
         return true;
     }
@@ -538,6 +531,11 @@ public:
     void cleanup() override {
         setVisible(false);
         CCNode::cleanup();
+    }
+
+    void removeChild(CCNode* child, bool cleanup) override {
+        CCNode::removeChild(child, cleanup);
+        removeFromParent();
     }
 };
 


### PR DESCRIPTION
- Fixes memory leak with `AutoCleanedCircleWave`, you forgot to call `autorelease` (oops).
- `playCircleEffectOnCmi` plays the effect on the `CreateMenuItem` now, instead of on some parent. This improves compatibility with Tinker, and simplifies the code. 
- Object finding will now properly set the current group instead of just the item inside it. 
- Similarly, `updateCreateMenu` now also sets the current group from `m_selectedObjectIndex`.
- Added `ObjectFoundEvent`, Tinker needs this so it can scroll to the right object.